### PR TITLE
Export temporary parent while dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ A maximum of 50 is allowed for when one wants to stick the draggable to the curs
 
 ---
 
+`drag_layer_parent` (Node, default: null)
+
+Node the draggable's area temporarily re-parents to while in DRAGGING state.
+The area shouldn't be an ancestor of this node. If unset, will use the tree root.
+
+_Hint_: 
+If the scene root is the Area2D, either assign `drag_layer_parent` at runtime once the game tree is available or
+transform the scene so that the root has the area as a child, 
+allowing the `drag_layer_parent` can be attached to something other than the area. 
+
+---
+
 `drag_z_index` (int, default: 1000)
 
 Controls the z-index of the draggable node while it is being dragged. This ensures that the draggable appears above other nodes during the drag operation.

--- a/addons/drag_and_drop/README.md
+++ b/addons/drag_and_drop/README.md
@@ -24,6 +24,18 @@ The name of the drag action that's set up in the project settings InputMap. For 
 
 ---
 
+`drag_layer_parent` (Node, default: null)
+
+Node the draggable's area temporarily re-parents to while in DRAGGING state.
+The area shouldn't be an ancestor of this node. If unset, will use the tree root.
+
+_Hint_: 
+If the scene root is the Area2D, either assign `drag_layer_parent` at runtime once the game tree is available or
+transform the scene so that the root has the area as a child, 
+allowing the `drag_layer_parent` can be attached to something other than the area. 
+
+---
+
 `dragging_speed` (float, default: 25.0)
 
 Controls the speed at which the draggable node moves towards the cursor or towards the drop zone when dropped or returning.

--- a/addons/drag_and_drop/scripts/draggable.gd
+++ b/addons/drag_and_drop/scripts/draggable.gd
@@ -17,7 +17,7 @@ enum DRAGGABLE_STATE {IDLE, DRAGGING, DROPPING, RETURNING, AUTO_MOVING}
 		drag_input_name = value
 		update_configuration_warnings()
 ## Node the draggable's area temporarily re-parents to while in DRAGGING state.
-## The area shouldn't be an ancestor of this node. 
+## The area shouldn't be an ancestor of this node. If unset, will use the tree root.
 ## [br][br]
 ## [i]Hint[/i]: 
 ## If the scene root is the Area2D, either assign [code]drag_layer_parent[/code] at runtime once the game tree is available or


### PR DESCRIPTION
Allows the addon user to select the node to which the Draggable gets reparented to. 
Fixes #1 